### PR TITLE
Add archetype for `hugo new`

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,0 +1,15 @@
+---
+title: "{{ replace .Name "_" " " | title }}"
+artist:
+date: {{ .Date }}
+cover: /upload/{{ replace .Name "_" " " | title }}.jpg
+styles:
+links:
+  spotify:
+  youtube:
+  applemusic:
+  soundcloud:
+  bandcamp:
+  deezer:
+---
+


### PR DESCRIPTION
This makes it so that using `hugo new content/a/whatever.md` generates the entry with the correct template. 